### PR TITLE
Use text/template and print queries if QUERY_DEBUG=1

### DIFF
--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"database/sql"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -75,7 +74,6 @@ func TestTableExclusions(t *testing.T) {
 
 	db := setupDB(&c)
 	var disabledCount int
-	fmt.Println(query)
 	scanErr := db.QueryRow(query).Scan(&disabledCount)
 	assert.NoError(t, scanErr)
 


### PR DESCRIPTION
Uses text/template package for templated queries rather than html/template. Also, checks QUERY_DEBUG env variable to determine whether to print queries to stdout before running them.